### PR TITLE
Charts: Respect also the year

### DIFF
--- a/page/plots/published.json
+++ b/page/plots/published.json
@@ -19,7 +19,7 @@
     ],
     "encoding": {
         "x": {
-            "timeUnit": "utcmonthdate",
+            "timeUnit": "utcyearmonthdate",
             "field": "date",
             "type": "temporal",
             "axis": {

--- a/page/plots/publishedByRisk.json
+++ b/page/plots/publishedByRisk.json
@@ -14,7 +14,7 @@
   ],
   "encoding": {
     "x": {
-      "timeUnit": "utcmonthdate",
+      "timeUnit": "utcyearmonthdate",
       "field": "date",
       "type": "temporal",
       "axis": {

--- a/page/plots/userPublishedByCount.json
+++ b/page/plots/userPublishedByCount.json
@@ -14,7 +14,7 @@
   ],
   "encoding": {
     "x": {
-      "timeUnit": "utcmonthdate",
+      "timeUnit": "utcyearmonthdate",
       "field": "date",
       "type": "temporal",
       "axis": {

--- a/page/plots/usercount.json
+++ b/page/plots/usercount.json
@@ -19,7 +19,7 @@
     ],
     "encoding": {
         "x": {
-            "timeUnit": "utcmonthdate",
+            "timeUnit": "utcyearmonthdate",
             "field": "date",
             "type": "temporal",
             "axis": {

--- a/page/plots/valid.json
+++ b/page/plots/valid.json
@@ -8,7 +8,7 @@
     },
     "encoding": {
         "x": {
-            "timeUnit": "utcmonthdate",
+            "timeUnit": "utcyearmonthdate",
             "field": "date",
             "type": "temporal",
             "axis": {

--- a/page/plots/validByRisk.json
+++ b/page/plots/validByRisk.json
@@ -14,7 +14,7 @@
   ],
   "encoding": {
     "x": {
-      "timeUnit": "utcmonthdate",
+      "timeUnit": "utcyearmonthdate",
       "field": "date",
       "type": "temporal",
       "axis": {


### PR DESCRIPTION
Fixes https://github.com/janpf/ctt/issues/9 so for example the same chart looks like:

![image](https://user-images.githubusercontent.com/319826/103454486-00d34680-4ce5-11eb-8069-ec8f4f31469a.png)
notice the "date (year-month-date)" label on the horizontal axis.